### PR TITLE
Add 518px Franca and DINOv2 checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,56 @@ Franca is released as a research project to promote transparency, reproducibilit
       <td align="center">82.0%</td>
       <td align="center">75.7%</td>
       <td align="center">39.1%</td>
-      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.0.0/franca_vitb14_In21k.pth">backbone only</a></td>
-      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.0.0/franca_vitb14_In21k_rasa.pth">RASA head</a></td>
+      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.0.0/franca_vitb14_In21K.pth">backbone only</a></td>
+      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.0.0/franca_vitb14_In21K_rasa.pth">RASA head</a></td>
+    </tr>
+    <tr>
+      <td>ViT-B/14</td>
+      <td align="left">86 M</td>
+      <td align="left">ImageNet, latest</td>
+      <td align="center">518</td>
+      <td align="center">N/A</td>
+      <td align="center">N/A</td>
+      <td align="center">N/A</td>
+      <td align="center">N/A</td>
+      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.1.0/franca_vitb14_In21K_518.pth">backbone only</a></td>
+      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.1.0/franca_vitb14_In21K_518_rasa.pth">RASA head</a></td>
+    </tr>
+    <tr>
+      <td>DINOv2 ViT-B/14</td>
+      <td align="left">86 M</td>
+      <td align="left">In21K HRFT</td>
+      <td align="center">518</td>
+      <td align="center">N/A</td>
+      <td align="center">N/A</td>
+      <td align="center">N/A</td>
+      <td align="center">N/A</td>
+      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.1.0/franca_vitb14_Dinov2_In21K_518.pth">backbone only</a></td>
+      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.1.0/franca_vitb14_Dinov2_In21K_518_rasa.pth">RASA head</a></td>
+    </tr>
+    <tr>
+      <td>DINOv2 ViT-L/14</td>
+      <td align="left">300 M</td>
+      <td align="left">In21K HRFT</td>
+      <td align="center">518</td>
+      <td align="center">N/A</td>
+      <td align="center">N/A</td>
+      <td align="center">N/A</td>
+      <td align="center">N/A</td>
+      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.1.0/franca_vitl14_Dinov2_In21K_518.pth">backbone only</a></td>
+      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.1.0/franca_vitl14_Dinov2_In21K_518_rasa.pth">RASA head</a></td>
+    </tr>
+    <tr>
+      <td>ViT-L/14</td>
+      <td align="left">300 M</td>
+      <td align="left">LAION-600M</td>
+      <td align="center">518</td>
+      <td align="center">N/A</td>
+      <td align="center">N/A</td>
+      <td align="center">N/A</td>
+      <td align="center">N/A</td>
+      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.1.0/franca_vitl14_Laion_518.pth">backbone only</a></td>
+      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.1.0/franca_vitl14_Laion_518_rasa.pth">RASA head</a></td>
     </tr>
     <tr>
       <td>ViT-L/14</td>
@@ -101,14 +149,14 @@ Franca is released as a research project to promote transparency, reproducibilit
       <td align="center">84.5%</td>
       <td align="center">73.5%</td>
       <td align="center">41.3%</td>
-      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.0.0/franca_vitl14_In21k.pth">backbone only</a></td>
-      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.0.0/franca_vitl14_In21k_rasa.pth">RASA head</a></td>
+      <td>not published</td>
+      <td>not published</td>
     </tr>
     <tr>
       <td>ViT-L/14</td>
       <td align="left">300 M</td>
       <td align="left">LAION-600M</td>
-      <td align="center">224</td>
+      <td align="center">518</td>
       <td align="center">81.9%</td>
       <td align="center">84.4%</td>
       <td align="center">73.5%</td>
@@ -125,8 +173,8 @@ Franca is released as a research project to promote transparency, reproducibilit
       <td align="center">85.9%</td>
       <td align="center">71.7%</td>
       <td align="center">40.2%</td>
-      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.0.0/franca_vitg14_In21k_chunked.tar.gz.part_aa">part 1</a>, <a href="https://github.com/valeoai/Franca/releases/download/v1.0.0/franca_vitg14_In21k_chunked.tar.gz.part_ab">part 2</a>, <a href="https://github.com/valeoai/Franca/releases/download/v1.0.0/franca_vitg14_In21k_chunked.tar.gz.part_ac">part 3</a></td>
-      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.0.0/franca_vitg14_In21K_rasa.pth">RASA head</a></td>
+      <td>not published</td>
+      <td>not published</td>
     </tr>
     <tr>
       <td>ViT-g/14</td>
@@ -138,7 +186,7 @@ Franca is released as a research project to promote transparency, reproducibilit
       <td align="center">76.7%</td>
       <td align="center">42.4%</td>
       <td><a href="https://github.com/valeoai/Franca/releases/download/v1.0.0/franca_vitg14_Laion600M_chunked.tar.gz.part_aa">part 1</a>, <a href="https://github.com/valeoai/Franca/releases/download/v1.0.0/franca_vitg14_Laion600M_chunked.tar.gz.part_ab">part 2</a>, <a href="https://github.com/valeoai/Franca/releases/download/v1.0.0/franca_vitg14_Laion600M_chunked.tar.gz.part_ac">part 3</a></td>
-      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.0.0/franca_vitl14_Laion600M_rasa.pth">RASA head</a></td>
+      <td><a href="https://github.com/valeoai/Franca/releases/download/v1.0.0/franca_vitg14_Laion600M_rasa.pth">RASA head</a></td>
     </tr>
   </tbody>
 </table>
@@ -153,8 +201,6 @@ import torch
 
 # Franca -- In21k
 franca_vitb14 = torch.hub.load('valeoai/Franca', 'franca_vitb14', use_rasa_head=True)
-franca_vitl14 = torch.hub.load('valeoai/Franca', 'franca_vitl14', use_rasa_head=True)
-franca_vitg14 = torch.hub.load('valeoai/Franca', 'franca_vitg14', use_rasa_head=True)
 
 # Franca -- Laion600M
 franca_vitl14 = torch.hub.load('valeoai/Franca', 'franca_vitl14', weights='LAION', use_rasa_head=True)
@@ -163,7 +209,21 @@ franca_vitg14 = torch.hub.load('valeoai/Franca', 'franca_vitg14', weights='LAION
 # Dinov2 baseline -- In21k
 franca_vitb14 = torch.hub.load('valeoai/Franca', 'franca_vitb14', weights='DINOV2_IN21K', use_rasa_head=False)
 franca_vitl14 = torch.hub.load('valeoai/Franca', 'franca_vitl14', weights='DINOV2_IN21K', use_rasa_head=False)
+
+# 518px checkpoints with RASA
+franca_vitb14_518 = torch.hub.load('valeoai/Franca', 'franca_vitb14', weights='IN21K_518', use_rasa_head=True)
+dinov2_vitb14_518 = torch.hub.load(
+    'valeoai/Franca', 'franca_vitb14', weights='DINOV2_IN21K_518', use_rasa_head=True
+)
+dinov2_vitl14_518 = torch.hub.load(
+    'valeoai/Franca', 'franca_vitl14', weights='DINOV2_IN21K_518', use_rasa_head=True
+)
+franca_vitl14_518 = torch.hub.load('valeoai/Franca', 'franca_vitl14', weights='LAION_518', use_rasa_head=True)
 ```
+
+The 518px Franca-L checkpoint uses the same LAION-600M dataset as the other LAION models. Legacy RASA checkpoints
+with eight preprocessing projections and current checkpoints with nine are both detected and loaded automatically.
+The three RASA files extracted from HRFT teacher checkpoints have the current 10-tensor structure.
 
 ## Installation
 
@@ -200,10 +260,6 @@ from franca.hub.backbones import _make_franca_model
 from rasa.src.rasa_head import RASAHead
 
 # --- Step 1: Choose model config ---
-arch_name = "vit_large"
-img_size = 224
-ckpt_path = "<your path>/franca_vitl14_In21K.pth"
-rasa_ckpt_path = "<your path>/franca_vitl14_In21K_rasa.pth"
 
 # Define image transformation
 transform = transforms.Compose([
@@ -214,15 +270,7 @@ transform = transforms.Compose([
 ])
 
 # --- Step 2: Build and load model ---
-model = _make_franca_model(
-    arch_name=arch_name,
-    img_size=img_size,
-    pretrained=True,
-    local_state_dict=ckpt_path,
-    RASA_local_state_dict=rasa_ckpt_path,
-    use_rasa_head=True
-)
-
+model = torch.hub.load('valeoai/Franca', 'franca_vitb14', use_rasa_head=True)
 
 # --- Step 3: Forward pass ---
 model.cuda()

--- a/franca/__init__.py
+++ b/franca/__init__.py
@@ -1,4 +1,4 @@
 # This source code is licensed under the Apache License, Version 2.0
 # found in the LICENSE file in the root directory of this source tree.
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/franca/hub/backbones.py
+++ b/franca/hub/backbones.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Optional, Union
+from typing import Any, Mapping, Optional, Union
 
 import torch
 import torch.nn as nn
@@ -10,7 +10,7 @@ import torch.nn as nn
 from franca.hub.utils import _TEMPDIR, extract_tar_file, load_state_dict_from_url
 from rasa.src.rasa_head import RASAHead
 
-_FRANCA_BASE_URL = "https://github.com/valeoai/Franca/releases/download/v1.0.0"
+_FRANCA_RELEASE_URL = "https://github.com/valeoai/Franca/releases/download/{release}"
 _FRANCA_ViT_G_CHUNKS = [
     "chunked.tar.gz.part_aa",
     "chunked.tar.gz.part_ab",
@@ -46,14 +46,93 @@ class FrancaConfig:
 
 class Weights(Enum):
     IN21K = "In21K"
+    IN21K_518 = "In21K_518"
     LAION = "Laion600M"
     DINOV2_IN21K = "Dinov2_In21K"
+    DINOV2_IN21K_518 = "Dinov2_In21K_518"
+    LAION_518 = "Laion_518"
+
+
+@dataclass(frozen=True)
+class WeightSpec:
+    img_size: int
+    release: str
+    rasa_available: bool = True
+
+
+_WEIGHT_SPECS = {
+    ("vit_base", Weights.IN21K): WeightSpec(img_size=518, release="v1.0.0"),
+    ("vit_base", Weights.IN21K_518): WeightSpec(img_size=518, release="v1.1.0"),
+    ("vit_base", Weights.DINOV2_IN21K): WeightSpec(img_size=224, release="v1.1.0", rasa_available=False),
+    ("vit_base", Weights.DINOV2_IN21K_518): WeightSpec(img_size=518, release="v1.1.0"),
+    ("vit_large", Weights.LAION): WeightSpec(img_size=518, release="v1.0.0"),
+    ("vit_large", Weights.DINOV2_IN21K): WeightSpec(img_size=224, release="v1.1.0", rasa_available=False),
+    ("vit_large", Weights.DINOV2_IN21K_518): WeightSpec(img_size=518, release="v1.1.0"),
+    ("vit_large", Weights.LAION_518): WeightSpec(img_size=518, release="v1.1.0"),
+    ("vit_giant2", Weights.LAION): WeightSpec(img_size=224, release="v1.0.0"),
+}
+
+
+def _normalize_weights(weights: Union[Weights, str]) -> Weights:
+    if isinstance(weights, Weights):
+        return weights
+    try:
+        return Weights[weights]
+    except KeyError as error:
+        supported = ", ".join(weight.name for weight in Weights)
+        raise ValueError(f"Unsupported weights: {weights}. Supported values: {supported}") from error
+
+
+def _get_weight_spec(arch_name: str, weights: Weights) -> WeightSpec:
+    try:
+        return _WEIGHT_SPECS[(arch_name, weights)]
+    except KeyError as error:
+        supported = ", ".join(weight.name for arch, weight in _WEIGHT_SPECS if arch == arch_name)
+        raise ValueError(f"Weights {weights.name} are not available for {arch_name}. Supported values: {supported}") from error
+
+
+def _make_checkpoint_url(arch_name: str, patch_size: int, weights: Weights, rasa: bool = False) -> str:
+    spec = _get_weight_spec(arch_name, weights)
+    base_url = _FRANCA_RELEASE_URL.format(release=spec.release)
+    if rasa:
+        model_name = _make_rasa_model_name(arch_name, patch_size, weights.value)
+    else:
+        model_name = _make_franca_model_name(arch_name, patch_size, weights.value)
+    return f"{base_url}/{model_name}.pth"
+
+
+def _normalize_rasa_state_dict(state_dict: Mapping[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    normalized = {}
+    for key, value in state_dict.items():
+        if key.startswith("module."):
+            key = key[len("module.") :]
+        if key.startswith("rasa_head."):
+            key = key[len("rasa_head.") :]
+        normalized[key] = value
+    return normalized
+
+
+def _make_rasa_head(input_dim: int, state_dict: Mapping[str, torch.Tensor]) -> RASAHead:
+    state_dict = _normalize_rasa_state_dict(state_dict)
+    layer_indices = sorted(
+        int(key.split(".")[1])
+        for key in state_dict
+        if key.startswith("pre_pos_layers.") and key.endswith(".weight")
+    )
+    if layer_indices != list(range(len(layer_indices))):
+        raise ValueError(f"RASA preprocessing layers must be contiguous from zero; found {layer_indices}")
+    if "pos_pred.weight" not in state_dict:
+        raise ValueError("RASA state dict is missing pos_pred.weight")
+
+    rasa_head = RASAHead(input_dim=input_dim, n_pos_layers=len(layer_indices), pos_out_dim=2)
+    rasa_head.load_state_dict(state_dict, strict=True)
+    return rasa_head
 
 
 def _make_franca_model(
     *,
     arch_name: str = "vit_large",
-    img_size: int = 224,
+    img_size: Optional[int] = None,
     pretrained: bool = True,
     weights: Union[Weights, str] = Weights.IN21K,
     local_state_dict: Optional[str | list[str]] = None,
@@ -62,14 +141,13 @@ def _make_franca_model(
 ) -> nn.Module:
     from ..models import build_model
 
-    if isinstance(weights, str):
-        try:
-            weights = Weights[weights]
-        except KeyError:
-            raise AssertionError(f"Unsupported weights: {weights}")
+    weights = _normalize_weights(weights)
+    weight_spec = _get_weight_spec(arch_name, weights)
+    if img_size is None:
+        img_size = weight_spec.img_size
 
     # Extract use_rasa_head from kwargs before passing to FrancaConfig
-    use_rasa_head = kwargs.pop('use_rasa_head', False)
+    use_rasa_head = kwargs.pop("use_rasa_head", False)
 
     vit_config = FrancaConfig(arch=arch_name, use_rasa_head=use_rasa_head, **kwargs)
     model, _ = build_model(vit_config, only_teacher=True, img_size=img_size)
@@ -77,11 +155,6 @@ def _make_franca_model(
     model_full_name = _make_franca_model_name(arch_name, vit_config.patch_size, weights.value)
 
     if pretrained:
-        if weights == Weights.LAION and arch_name == "vit_base":
-            raise ValueError(
-                "Franca ViT-B/14 model is not available with LAION weights. "
-                "Please use IN21K weights or set `pretrained=False`."
-            )
         if local_state_dict is not None:
             if os.path.isdir(local_state_dict):
                 with tempfile.TemporaryDirectory(dir=_TEMPDIR) as tmpdirname:
@@ -91,9 +164,10 @@ def _make_franca_model(
                 state_dict = torch.load(local_state_dict, map_location="cpu", weights_only=True)
         else:
             if arch_name == "vit_giant2":
-                url = [_FRANCA_BASE_URL + f"/{model_full_name}_{chunk}" for chunk in _FRANCA_ViT_G_CHUNKS]
+                base_url = _FRANCA_RELEASE_URL.format(release=weight_spec.release)
+                url = [base_url + f"/{model_full_name}_{chunk}" for chunk in _FRANCA_ViT_G_CHUNKS]
             else:
-                url = _FRANCA_BASE_URL + f"/{model_full_name}.pth"
+                url = _make_checkpoint_url(arch_name, vit_config.patch_size, weights)
             state_dict = load_state_dict_from_url(url, map_location="cpu", weights_only=True)
 
         state_dict: dict[str, Any] = state_dict["teacher"]
@@ -131,24 +205,15 @@ def _make_franca_model(
     assert len(model.blocks) == model.n_blocks, f"Expected {model.n_blocks} blocks, but got {len(model.blocks)} blocks."
 
     if vit_config.use_rasa_head:
-        rasa_head = RASAHead(input_dim=model.embed_dim, n_pos_layers=9, pos_out_dim=2)
-
+        if RASA_local_state_dict is None and not weight_spec.rasa_available:
+            raise ValueError(f"RASA weights are not published for {arch_name} with {weights.name} weights.")
         if RASA_local_state_dict is not None:
             rasa_state_dict = torch.load(RASA_local_state_dict, map_location="cpu", weights_only=True)
         else:
-            rasa_model_name = _make_rasa_model_name(arch_name, vit_config.patch_size, weights.value)
-            rasa_url = _FRANCA_BASE_URL + f"/{rasa_model_name}.pth"
+            rasa_url = _make_checkpoint_url(arch_name, vit_config.patch_size, weights, rasa=True)
             rasa_state_dict = load_state_dict_from_url(rasa_url, map_location="cpu", weights_only=True)
 
-        # Load the RASA head state dict
-        msg = rasa_head.load_state_dict(rasa_state_dict)
-        if len(msg.missing_keys) != 0:
-            raise ValueError(
-                f"Missing keys in the RASA head state_dict: {msg.missing_keys}. "
-                "Ensure that the RASA head architecture matches the state_dict."
-            )
-
-        model.rasa_head = rasa_head
+        model.rasa_head = _make_rasa_head(model.embed_dim, rasa_state_dict)
 
     if not vit_config.use_rasa_head and hasattr(model, "rasa_head"):
         del model.rasa_head
@@ -160,10 +225,7 @@ def franca_vitb14(*, pretrained: bool = True, weights: Union[Weights, str] = Wei
     """
     Franca ViT-B/14 model (optionally) pretrained on the In21K dataset.
     """
-    if weights == Weights.DINOV2_IN21K or weights == "DINOV2_IN21K":
-        img_size = kwargs.pop("img_size", 224)
-    else:
-        img_size = kwargs.pop("img_size", 518)
+    img_size = kwargs.pop("img_size", None)
     return _make_franca_model(arch_name="vit_base", pretrained=pretrained, weights=weights, img_size=img_size, **kwargs)
 
 
@@ -171,11 +233,13 @@ def franca_vitl14(*, pretrained: bool = True, weights: Union[Weights, str] = Wei
     """
     Franca ViT-L/14 model (optionally) pretrained on either the In21K or Laion600M dataset.
     """
-    return _make_franca_model(arch_name="vit_large", pretrained=pretrained, weights=weights, **kwargs)
+    img_size = kwargs.pop("img_size", None)
+    return _make_franca_model(arch_name="vit_large", pretrained=pretrained, weights=weights, img_size=img_size, **kwargs)
 
 
 def franca_vitg14(*, pretrained: bool = True, weights: Union[Weights, str] = Weights.IN21K, **kwargs) -> nn.Module:
     """
     Franca ViT-g/14 model (optionally) pretrained on either the In21K or Laion600M dataset.
     """
-    return _make_franca_model(arch_name="vit_giant2", weights=weights, pretrained=pretrained, **kwargs)
+    img_size = kwargs.pop("img_size", None)
+    return _make_franca_model(arch_name="vit_giant2", weights=weights, pretrained=pretrained, img_size=img_size, **kwargs)

--- a/model_card.md
+++ b/model_card.md
@@ -3,10 +3,11 @@
 These are Vision Transformer models trained following the method described in the papers:
 "Franca: Nested Clustering with Matryoshka for Scalable Visual Representation Learning"
 
-We provide 7 models:
+We provide the original 7 models and four 518px backbone/RASA checkpoint pairs:
 - DINOv2-B and DINOv2-L reproduced on IN-21K. (without distillation)
 - Franca-B, Franca-L and Franca-G pretrained on IN-21K.
 - Franca-L and Franca-G pretrained on LAION-600M.
+- Franca-B continued at 518px, DINOv2-B/L 518px HRFT baselines, and Franca-L trained at 518px on LAION HRFT shards.
 
 ## Model Details
 The model takes an image as input and returns a class token and patch tokens
@@ -54,17 +55,29 @@ import torch
 
 # Franca -- In21k
 franca_vitb14 = torch.hub.load('valeoai/Franca', 'franca_vitb14', use_rasa_head=True)
-franca_vitl14 = torch.hub.load('valeoai/Franca', 'franca_vitl14', use_rasa_head=True)
-franca_vitg14 = torch.hub.load('valeoai/Franca', 'franca_vitg14', use_rasa_head=True)
 
 # Franca -- Laion600M
-franca_vitl14 = torch.hub.load('valeoai/Franca', 'franca_vitl14', weights='LAION600m', use_rasa_head=True)
-franca_vitg14 = torch.hub.load('valeoai/Franca', 'franca_vitg14', weights='LAION600m', use_rasa_head=True)
+franca_vitl14 = torch.hub.load('valeoai/Franca', 'franca_vitl14', weights='LAION', use_rasa_head=True)
+franca_vitg14 = torch.hub.load('valeoai/Franca', 'franca_vitg14', weights='LAION', use_rasa_head=True)
 
 # Dinov2 baseline -- In21k
 franca_vitb14 = torch.hub.load('valeoai/Franca', 'franca_vitb14', weights='DINOV2_IN21K', use_rasa_head=False)
 franca_vitl14 = torch.hub.load('valeoai/Franca', 'franca_vitl14', weights='DINOV2_IN21K', use_rasa_head=False)
+
+# 518px variants
+franca_vitb14_518 = torch.hub.load('valeoai/Franca', 'franca_vitb14', weights='IN21K_518', use_rasa_head=True)
+dinov2_vitb14_518 = torch.hub.load(
+    'valeoai/Franca', 'franca_vitb14', weights='DINOV2_IN21K_518', use_rasa_head=True
+)
+dinov2_vitl14_518 = torch.hub.load(
+    'valeoai/Franca', 'franca_vitl14', weights='DINOV2_IN21K_518', use_rasa_head=True
+)
+franca_vitl14_518 = torch.hub.load('valeoai/Franca', 'franca_vitl14', weights='LAION_518', use_rasa_head=True)
 ```
+
+The Franca-L 518px checkpoint uses the same LAION-600M dataset as the other LAION models. The RASA heads extracted
+from the three HRFT teacher checkpoints have the expected current 10-tensor structure. The loader also supports
+legacy 9-tensor RASA checkpoints by inferring the number of preprocessing projections from each state dictionary.
 
 
 ## Loading intermediate checkpoints
@@ -82,14 +95,14 @@ from rasa.src.rasa_head import RASAHead
 
 # --- Step 1: Choose model config ---
 arch_name = "vit_large"
-img_size = 224
-ckpt_path = "<your path>/franca_vitl14_In21K.pth"
-rasa_ckpt_path = "<your path>/franca_vitl14_In21K_rasa.pth"
+img_size = 518
+ckpt_path = "<your path>/franca_vitl14_Laion_518.pth"
+rasa_ckpt_path = "<your path>/franca_vitl14_Laion_518_rasa.pth"
 
 # Define image transformation
 transform = transforms.Compose([
-    transforms.Resize(256, interpolation=transforms.InterpolationMode.BICUBIC),
-    transforms.CenterCrop(224),
+    transforms.Resize(518, interpolation=transforms.InterpolationMode.BICUBIC),
+    transforms.CenterCrop(518),
     transforms.ToTensor(),
     transforms.Normalize(mean=(0.485, 0.456, 0.406), std=(0.229, 0.224, 0.225))
 ])
@@ -98,6 +111,7 @@ transform = transforms.Compose([
 model = _make_franca_model(
     arch_name=arch_name,
     img_size=img_size,
+    weights="LAION_518",
     pretrained=True,
     local_state_dict=ckpt_path,
     RASA_local_state_dict=rasa_ckpt_path,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "franca"
-version = "1.0.0"
+version = "1.1.0"
 description = "Franca: Nested Matryoshka Clustering for Scalable Visual Representation Learning (official repository)."
 readme = "README.md"
 requires-python = ">=3.8.0"

--- a/release_checkpoints.md
+++ b/release_checkpoints.md
@@ -1,0 +1,57 @@
+# Preparing the 518px checkpoint release
+
+The v1.1.0 release contains four 518px backbone/RASA pairs and republishes the missing legacy DINOv2-B/L 224px
+backbones. Backbone assets use the existing `{"teacher": state_dict}` format; new RASA assets are standalone
+10-tensor state dictionaries.
+
+## Build and verify
+
+Run from the repository root in an environment containing PyTorch:
+
+```bash
+python scripts/prepare_release_checkpoints.py \
+  --output-dir /hnvme/workspace/v115be14-ws/checkpoints/franca/release_v1.1.0
+
+python scripts/verify_release_checkpoints.py \
+  /hnvme/workspace/v115be14-ws/checkpoints/franca/release_v1.1.0
+```
+
+The exporter removes training-only DINO/iBOT heads, separates embedded RASA tensors, validates architecture and
+position-embedding shapes, and writes `CHECKPOINTS.json` plus `SHA256SUMS`.
+
+## Publish
+
+An isolated environment containing Python 3.9 and GitHub CLI 2.97.0 is available at
+`/hnvme/workspace/v115be14-ws/envs/franca-release`. Activate and authenticate it with:
+
+```bash
+source /hnvme/workspace/v115be14-ws/envs/franca-release/bin/activate
+gh auth login --hostname github.com --web
+gh auth status
+```
+
+Publishing requires write access to `valeoai/Franca`. First commit this repository's changes and move or merge that
+commit into a public Franca branch. Then run:
+
+```bash
+scripts/upload_gh_ckpt.sh \
+  /hnvme/workspace/v115be14-ws/checkpoints/franca/release_v1.1.0 \
+  v1.1.0 valeoai/Franca PUBLIC_CODE_REF
+```
+
+Replace `PUBLIC_CODE_REF` with the public branch or commit containing these loader changes. The script validates every
+checksum, creates a draft v1.1.0 release at that exact ref when necessary, and uploads the required assets without
+replacing existing ones. Test one clean `torch.hub.load` download from the tag, then publish the draft release.
+
+## Provenance limits
+
+- Franca-B: ImageNet training at 518px initialized from ImageNet-21K weights. Its RASA head is
+  the existing standalone B-518 checkpoint.
+- DINOv2-B/L: checkpoint names identify them as In21K 518px HRFT baselines. No adjacent training config was retained.
+- Franca-L: trained at 518px on the same LAION-600M dataset as the other LAION Franca models.
+- Legacy B-In21K and L-LAION RASA assets have eight preprocessing projections; the new assets have nine. The loader
+  infers this count, so both formats work.
+- The published v1.0.0 L-LAION backbone has a 518px positional grid even though the old README listed 224px. The
+  loader now constructs it at 518px; patch-size-compatible inference resolutions still use positional interpolation.
+- The retained local `franca_vitl14_In21K.pth` is identical to DINOv2-L and is therefore not published as Franca-L.
+- The v1.0.0 G-In21K release is incomplete and no valid local source was found, so that combination is not exposed.

--- a/scripts/prepare_release_checkpoints.py
+++ b/scripts/prepare_release_checkpoints.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Export the four 518px backbone/RASA pairs for the v1.1.0 release."""
+
+import argparse
+import hashlib
+import json
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping
+
+import torch
+
+
+RELEASES = (
+    {
+        "id": "franca_vitb14_in21k_518",
+        "arch": "vit_base",
+        "resolution": 518,
+        "dataset": "ImageNet training at 518px, initialized from ImageNet-21K weights",
+        "backbone_source": "teachers/franca_vitb/teacher_checkpoint.pth",
+        "rasa_source": "franca_vitb14_In21K_rasa.pth",
+        "backbone_asset": "franca_vitb14_In21K_518.pth",
+        "rasa_asset": "franca_vitb14_In21K_518_rasa.pth",
+        "rasa_provenance": "standalone RASA checkpoint",
+        "expected_backbone_keys": 175,
+        "embed_dim": 768,
+    },
+    {
+        "id": "dinov2_vitb14_in21k_518",
+        "arch": "vit_base",
+        "resolution": 518,
+        "dataset": "DINOv2 In21K baseline, 518px HRFT checkpoint",
+        "backbone_source": "teachers/dinov2_vitb_hrft_518/teacher_checkpoint.pth",
+        "rasa_source": "teachers/dinov2_vitb_hrft_518/teacher_checkpoint.pth",
+        "backbone_asset": "franca_vitb14_Dinov2_In21K_518.pth",
+        "rasa_asset": "franca_vitb14_Dinov2_In21K_518_rasa.pth",
+        "rasa_provenance": "embedded RASA tensors; training provenance not independently recorded",
+        "expected_backbone_keys": 175,
+        "embed_dim": 768,
+    },
+    {
+        "id": "dinov2_vitl14_in21k_518",
+        "arch": "vit_large",
+        "resolution": 518,
+        "dataset": "DINOv2 In21K baseline, 518px HRFT checkpoint",
+        "backbone_source": "teachers/dinov2_vitl_hrft_518/teacher_checkpoint.pth",
+        "rasa_source": "teachers/dinov2_vitl_hrft_518/teacher_checkpoint.pth",
+        "backbone_asset": "franca_vitl14_Dinov2_In21K_518.pth",
+        "rasa_asset": "franca_vitl14_Dinov2_In21K_518_rasa.pth",
+        "rasa_provenance": "embedded RASA tensors; training provenance not independently recorded",
+        "expected_backbone_keys": 343,
+        "embed_dim": 1024,
+    },
+    {
+        "id": "franca_vitl14_laion_518",
+        "arch": "vit_large",
+        "resolution": 518,
+        "dataset": "LAION-600M, 518px HRFT checkpoint",
+        "backbone_source": "teachers/franca_vitl/teacher_checkpoint.pth",
+        "rasa_source": "teachers/franca_vitl/teacher_checkpoint.pth",
+        "backbone_asset": "franca_vitl14_Laion_518.pth",
+        "rasa_asset": "franca_vitl14_Laion_518_rasa.pth",
+        "rasa_provenance": "embedded RASA tensors; training provenance not independently recorded",
+        "expected_backbone_keys": 343,
+        "embed_dim": 1024,
+    },
+    {
+        "id": "dinov2_vitb14_in21k_224",
+        "arch": "vit_base",
+        "resolution": 224,
+        "dataset": "DINOv2 In21K baseline",
+        "backbone_source": "franca_vitb14_Dinov2_In21K.pth",
+        "backbone_asset": "franca_vitb14_Dinov2_In21K.pth",
+        "rasa_provenance": "RASA is not available for this legacy baseline",
+        "expected_backbone_keys": 175,
+        "embed_dim": 768,
+    },
+    {
+        "id": "dinov2_vitl14_in21k_224",
+        "arch": "vit_large",
+        "resolution": 224,
+        "dataset": "DINOv2 In21K baseline",
+        "backbone_source": "franca_vitl14_Dinov2_In21K.pth",
+        "backbone_asset": "franca_vitl14_Dinov2_In21K.pth",
+        "rasa_provenance": "RASA is not available for this legacy baseline",
+        "expected_backbone_keys": 343,
+        "embed_dim": 1024,
+    },
+)
+
+EXCLUDED_PREFIXES = ("dino_head.", "ibot_head.", "rasa_head.")
+
+
+def strip_training_prefixes(key: str) -> str:
+    if key.startswith("module."):
+        key = key[len("module.") :]
+    if key.startswith("backbone."):
+        key = key[len("backbone.") :]
+    return key
+
+
+def load_checkpoint(path: Path) -> Any:
+    try:
+        return torch.load(path, map_location="cpu", weights_only=True, mmap=True)
+    except TypeError:
+        return torch.load(path, map_location="cpu")
+
+
+def teacher_state(path: Path) -> Mapping[str, torch.Tensor]:
+    checkpoint = load_checkpoint(path)
+    if not isinstance(checkpoint, Mapping) or "teacher" not in checkpoint:
+        raise ValueError(f"{path} does not contain a 'teacher' state dict")
+    return checkpoint["teacher"]
+
+
+def extract_backbone(path: Path) -> "OrderedDict[str, torch.Tensor]":
+    result = OrderedDict()
+    for key, value in teacher_state(path).items():
+        key = strip_training_prefixes(key)
+        if not key.startswith(EXCLUDED_PREFIXES):
+            result[key] = value
+    return result
+
+
+def extract_rasa(path: Path) -> "OrderedDict[str, torch.Tensor]":
+    checkpoint = load_checkpoint(path)
+    state = checkpoint["teacher"] if isinstance(checkpoint, Mapping) and "teacher" in checkpoint else checkpoint
+    normalized = OrderedDict((strip_training_prefixes(key), value) for key, value in state.items())
+    embedded = OrderedDict(
+        (key[len("rasa_head.") :], value) for key, value in normalized.items() if key.startswith("rasa_head.")
+    )
+    return embedded or normalized
+
+
+def validate_states(
+    spec: Mapping[str, Any], backbone: Mapping[str, torch.Tensor], rasa: Mapping[str, torch.Tensor] | None
+) -> None:
+    if len(backbone) != spec["expected_backbone_keys"]:
+        raise ValueError(f"{spec['id']}: expected {spec['expected_backbone_keys']} backbone keys, found {len(backbone)}")
+    if rasa is not None and len(rasa) != 10:
+        raise ValueError(f"{spec['id']}: expected 10 RASA keys, found {len(rasa)}")
+    if any(key.startswith(EXCLUDED_PREFIXES) for key in backbone):
+        raise ValueError(f"{spec['id']}: training-head tensors remain in backbone export")
+
+    pos_embed = backbone.get("pos_embed")
+    patch_weight = backbone.get("patch_embed.proj.weight")
+    expected_pos_tokens = (spec["resolution"] // 14) ** 2 + 1
+    if pos_embed is None or tuple(pos_embed.shape) != (1, expected_pos_tokens, spec["embed_dim"]):
+        raise ValueError(f"{spec['id']}: unexpected pos_embed shape")
+    if patch_weight is None or tuple(patch_weight.shape) != (spec["embed_dim"], 3, 14, 14):
+        raise ValueError(f"{spec['id']}: unexpected patch embedding shape")
+
+
+def save_checkpoint(value: Any, path: Path, force: bool) -> None:
+    if path.exists() and not force:
+        raise FileExistsError(f"Refusing to overwrite {path}; pass --force to replace it")
+    temporary_path = path.with_suffix(path.suffix + ".tmp")
+    torch.save(value, temporary_path)
+    temporary_path.replace(path)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(16 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_checksums(paths: Iterable[Path], output_path: Path) -> None:
+    lines = [f"{sha256(path)}  {path.name}" for path in sorted(paths)]
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source-root",
+        type=Path,
+        default=Path("/hnvme/workspace/v115be14-ws/checkpoints/franca"),
+        help="Directory containing teachers/ and the standalone Franca-B RASA checkpoint",
+    )
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    metadata: Dict[str, Any] = {
+        "release": "v1.1.0",
+        "format": "Franca teacher backbone with optional standalone RASA",
+        "models": [],
+    }
+    asset_paths = []
+
+    for spec in RELEASES:
+        backbone_source = args.source_root / spec["backbone_source"]
+        rasa_source = args.source_root / spec["rasa_source"] if spec.get("rasa_source") else None
+        if not backbone_source.is_file() or (rasa_source is not None and not rasa_source.is_file()):
+            raise FileNotFoundError(f"Missing source for {spec['id']}: {backbone_source} or {rasa_source}")
+
+        backbone = extract_backbone(backbone_source)
+        rasa = extract_rasa(rasa_source) if rasa_source is not None else None
+        validate_states(spec, backbone, rasa)
+
+        backbone_path = args.output_dir / spec["backbone_asset"]
+        save_checkpoint({"teacher": backbone}, backbone_path, args.force)
+        asset_paths.append(backbone_path)
+
+        rasa_path = args.output_dir / spec["rasa_asset"] if spec.get("rasa_asset") else None
+        if rasa_path is not None and rasa is not None:
+            save_checkpoint(rasa, rasa_path, args.force)
+            asset_paths.append(rasa_path)
+
+        public_spec = {key: value for key, value in spec.items() if not key.endswith("_source")}
+        public_spec["backbone_bytes"] = backbone_path.stat().st_size
+        if rasa_path is not None:
+            public_spec["rasa_bytes"] = rasa_path.stat().st_size
+            public_spec["rasa_preprocessing_layers"] = len(
+                [key for key in rasa if key.startswith("pre_pos_layers.") and key.endswith(".weight")]
+            )
+        metadata["models"].append(public_spec)
+        print(f"exported {spec['id']}")
+
+    metadata_path = args.output_dir / "CHECKPOINTS.json"
+    metadata_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+    write_checksums((*asset_paths, metadata_path), args.output_dir / "SHA256SUMS")
+    print(f"release assets are ready in {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upload_gh_ckpt.sh
+++ b/scripts/upload_gh_ckpt.sh
@@ -1,32 +1,98 @@
-# In the following directory, we should store all ViT-B/L checkpoints.
-# The names should have the following format:
-# franca_vitb14_In21K.pth, i.e., franca_{compact_arch_name}{patch_size}_{pretraining_dataset}.pth
-# dataset names are In21K or Laion600M.
-# you can check it out in franca/hub/backbones.py
-ALL_FINAL_WEIGHTS_DIR="$HOME/iveco/shashank/logfiles/franca_release_weights"
+#!/usr/bin/env bash
+set -euo pipefail
 
-# In the following directory, we should store all ViT-G checkpoints.
-# They should have the same following format as described above.
-GIGA_WEIGHTS_DIR="$HOME/iveco/shashank/logfiles/giga_models"
+ASSETS_DIR="${1:?usage: $0 ASSETS_DIR [RELEASE_TAG] [REPOSITORY] [PUBLIC_CODE_REF]}"
+RELEASE_TAG="${2:-v1.1.0}"
+REPOSITORY="${3:-valeoai/Franca}"
+PUBLIC_CODE_REF="${4:-}"
 
-_GITHUB_MAX_SIZE="1900MB"
+command -v gh >/dev/null || { echo "GitHub CLI (gh) is required" >&2; exit 1; }
+gh auth status >/dev/null
 
-# We split the giga model for both Ink21K and LAION into chunks of 1900MB each.
-# This is because GitHub has a limit of 2GB per file.
-tar czf - -C $GIGA_WEIGHTS_DIR franca_vitg14_In21K.pth | split -b $_GITHUB_MAX_SIZE - $ALL_FINAL_WEIGHTS_DIR/franca_vitg14_In21K_chunked.tar.gz.part_
-tar czf - -C $GIGA_WEIGHTS_DIR franca_vitg14_Laion600M.pth | split -b $_GITHUB_MAX_SIZE - $ALL_FINAL_WEIGHTS_DIR/franca_vitg14_Laion600M_chunked.tar.gz.part_
+required=(
+  franca_vitb14_In21K_518.pth
+  franca_vitb14_In21K_518_rasa.pth
+  franca_vitb14_Dinov2_In21K_518.pth
+  franca_vitb14_Dinov2_In21K_518_rasa.pth
+  franca_vitb14_Dinov2_In21K.pth
+  franca_vitl14_Dinov2_In21K_518.pth
+  franca_vitl14_Dinov2_In21K_518_rasa.pth
+  franca_vitl14_Dinov2_In21K.pth
+  franca_vitl14_Laion_518.pth
+  franca_vitl14_Laion_518_rasa.pth
+  CHECKPOINTS.json
+  SHA256SUMS
+)
 
-
-# Here we use GitHub CLI to upload the files to the Franca release.
-# Here are the instructions to install GitHub CLI:
-# https://github.com/cli/cli#installation
-# Make sure you have authenticated with GitHub CLI before running this script.
-# You can authenticate by running:
-# gh auth login
-# see: https://cli.github.com/manual/gh_auth_login
-find $ALL_FINAL_WEIGHTS_DIR -type f -name "*.pth" -o -name "*.tar.gz*" | while read -r filepath; do
-    # Copy the file to the destination with the new name
-    echo "[ ] Uploading: $filepath"
-    gh release upload v1.0.0 $filepath --clobber --repo valeoai/Franca
-    echo "[x] Uploaded: $filepath"
+assets=()
+for name in "${required[@]}"; do
+  path="$ASSETS_DIR/$name"
+  [[ -f "$path" ]] || { echo "Missing release asset: $path" >&2; exit 1; }
+  assets+=("$path")
 done
+
+(cd "$ASSETS_DIR" && sha256sum --check SHA256SUMS)
+
+if ! gh release view "$RELEASE_TAG" --repo "$REPOSITORY" >/dev/null 2>&1; then
+  if [[ -z "$PUBLIC_CODE_REF" ]]; then
+    echo "Release $RELEASE_TAG does not exist. Pass the public branch or commit containing the v1.1.0 loader as argument 4." >&2
+    exit 1
+  fi
+  gh release create "$RELEASE_TAG" --repo "$REPOSITORY" --draft --title "Franca $RELEASE_TAG checkpoints" \
+    --target "$PUBLIC_CODE_REF" \
+    --notes "Adds Franca and DINOv2 baseline checkpoints trained or continued at 518px. See CHECKPOINTS.json for provenance."
+fi
+
+release_info="$(gh release view "$RELEASE_TAG" --repo "$REPOSITORY" --json databaseId,isDraft,targetCommitish)"
+release_id="$(printf '%s' "$release_info" | jq --raw-output '.databaseId')"
+release_target="$(printf '%s' "$release_info" | jq --raw-output '.targetCommitish')"
+is_draft="$(printf '%s' "$release_info" | jq --raw-output '.isDraft')"
+
+if [[ "$is_draft" != "true" ]]; then
+  echo "Release $RELEASE_TAG is already published; refusing to modify it" >&2
+  exit 1
+fi
+
+if [[ -n "$PUBLIC_CODE_REF" && "$release_target" != "$PUBLIC_CODE_REF" ]]; then
+  gh release edit "$RELEASE_TAG" --repo "$REPOSITORY" --target "$PUBLIC_CODE_REF"
+  release_target="$PUBLIC_CODE_REF"
+fi
+
+if ! gh api "repos/$REPOSITORY/contents/franca/hub/backbones.py?ref=$release_target" --jq '.content' \
+  | base64 --decode | grep --quiet 'IN21K_518'; then
+  echo "Release target $release_target does not contain the v1.1.0 loader changes; publish the code first" >&2
+  exit 1
+fi
+
+for path in "${assets[@]}"; do
+  name="$(basename "$path")"
+  local_size="$(stat --format='%s' "$path")"
+  local_digest="sha256:$(sha256sum "$path" | cut --delimiter=' ' --fields=1)"
+  remote_info="$(
+    gh api "repos/$REPOSITORY/releases/$release_id" \
+      --jq ".assets[] | select(.name == \"$name\") | [.size, .digest] | @tsv"
+  )"
+  if [[ -n "$remote_info" ]]; then
+    IFS=$'\t' read -r remote_size remote_digest <<< "$remote_info"
+    if [[ "$remote_size" != "$local_size" || "$remote_digest" != "$local_digest" ]]; then
+      echo "Remote asset $name does not match the local size and SHA-256 digest; refusing to overwrite it" >&2
+      exit 1
+    fi
+    echo "Already uploaded and verified: $name"
+    continue
+  fi
+
+  gh release upload "$RELEASE_TAG" "$path" --repo "$REPOSITORY"
+  remote_info="$(
+    gh api "repos/$REPOSITORY/releases/$release_id" \
+      --jq ".assets[] | select(.name == \"$name\") | [.size, .digest] | @tsv"
+  )"
+  IFS=$'\t' read -r remote_size remote_digest <<< "$remote_info"
+  if [[ "$remote_size" != "$local_size" || "$remote_digest" != "$local_digest" ]]; then
+    echo "Uploaded asset $name failed remote size or SHA-256 verification" >&2
+    exit 1
+  fi
+  echo "Uploaded and verified: $name"
+done
+
+echo "All assets are present with the expected sizes and SHA-256 digests in draft release $REPOSITORY@$RELEASE_TAG"

--- a/scripts/upload_gh_ckpt.sh
+++ b/scripts/upload_gh_ckpt.sh
@@ -59,7 +59,7 @@ if [[ -n "$PUBLIC_CODE_REF" && "$release_target" != "$PUBLIC_CODE_REF" ]]; then
 fi
 
 if ! gh api "repos/$REPOSITORY/contents/franca/hub/backbones.py?ref=$release_target" --jq '.content' \
-  | base64 --decode | grep --quiet 'IN21K_518'; then
+  | base64 --decode | grep 'IN21K_518' >/dev/null; then
   echo "Release target $release_target does not contain the v1.1.0 loader changes; publish the code first" >&2
   exit 1
 fi

--- a/scripts/verify_release_checkpoints.py
+++ b/scripts/verify_release_checkpoints.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Strict-load and optionally forward-test the v1.1.0 release checkpoints."""
+
+import argparse
+import gc
+import json
+import sys
+from pathlib import Path
+
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from franca.hub.backbones import _make_franca_model
+
+
+WEIGHT_NAMES = {
+    "franca_vitb14_in21k_518": "IN21K_518",
+    "dinov2_vitb14_in21k_518": "DINOV2_IN21K_518",
+    "dinov2_vitl14_in21k_518": "DINOV2_IN21K_518",
+    "franca_vitl14_laion_518": "LAION_518",
+    "dinov2_vitb14_in21k_224": "DINOV2_IN21K",
+    "dinov2_vitl14_in21k_224": "DINOV2_IN21K",
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("assets_dir", type=Path)
+    parser.add_argument("--skip-forward", action="store_true", help="Only test checkpoint structure and strict model loading")
+    args = parser.parse_args()
+
+    metadata = json.loads((args.assets_dir / "CHECKPOINTS.json").read_text(encoding="utf-8"))
+    for item in metadata["models"]:
+        use_rasa_head = "rasa_asset" in item
+        rasa_path = str(args.assets_dir / item["rasa_asset"]) if use_rasa_head else None
+        model = _make_franca_model(
+            arch_name=item["arch"],
+            weights=WEIGHT_NAMES[item["id"]],
+            local_state_dict=str(args.assets_dir / item["backbone_asset"]),
+            RASA_local_state_dict=rasa_path,
+            use_rasa_head=use_rasa_head,
+        )
+        assert model.patch_embed.img_size == (item["resolution"], item["resolution"])
+
+        if not args.skip_forward:
+            model.eval()
+            image = torch.zeros(1, 3, item["resolution"], item["resolution"])
+            with torch.inference_mode():
+                features = model.forward_features(image, use_rasa_head=use_rasa_head)
+            expected_patches = (item["resolution"] // 14) ** 2
+            assert features["x_norm_patchtokens"].shape == (1, expected_patches, item["embed_dim"])
+            if use_rasa_head:
+                assert features["patch_token_rasa"].shape == (1, expected_patches, item["embed_dim"])
+
+        print(f"verified {item['id']}")
+        del model
+        gc.collect()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hub_backbones.py
+++ b/tests/test_hub_backbones.py
@@ -1,0 +1,58 @@
+import unittest
+
+import torch
+
+from franca.hub.backbones import Weights, _get_weight_spec, _make_checkpoint_url, _make_rasa_head
+
+
+class ReleaseRoutingTest(unittest.TestCase):
+    def test_518_release_urls(self):
+        expected = {
+            ("vit_base", Weights.IN21K_518): "franca_vitb14_In21K_518",
+            ("vit_base", Weights.DINOV2_IN21K_518): "franca_vitb14_Dinov2_In21K_518",
+            ("vit_large", Weights.DINOV2_IN21K_518): "franca_vitl14_Dinov2_In21K_518",
+            ("vit_large", Weights.LAION_518): "franca_vitl14_Laion_518",
+        }
+        for (arch, weights), asset_stem in expected.items():
+            with self.subTest(arch=arch, weights=weights):
+                self.assertEqual(_get_weight_spec(arch, weights).img_size, 518)
+                self.assertEqual(
+                    _make_checkpoint_url(arch, 14, weights),
+                    f"https://github.com/valeoai/Franca/releases/download/v1.1.0/{asset_stem}.pth",
+                )
+                self.assertEqual(
+                    _make_checkpoint_url(arch, 14, weights, rasa=True),
+                    f"https://github.com/valeoai/Franca/releases/download/v1.1.0/{asset_stem}_rasa.pth",
+                )
+
+    def test_legacy_weights_stay_on_v1_0_0(self):
+        url = _make_checkpoint_url("vit_base", 14, Weights.IN21K)
+        self.assertIn("/v1.0.0/", url)
+        self.assertEqual(_get_weight_spec("vit_large", Weights.LAION).img_size, 518)
+
+    def test_legacy_dinov2_weights_are_republished(self):
+        for arch in ("vit_base", "vit_large"):
+            with self.subTest(arch=arch):
+                url = _make_checkpoint_url(arch, 14, Weights.DINOV2_IN21K)
+                self.assertIn("/v1.1.0/", url)
+
+    def test_unsupported_combination_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "not available"):
+            _get_weight_spec("vit_base", Weights.LAION_518)
+
+    def test_unavailable_legacy_models_are_rejected(self):
+        for arch in ("vit_large", "vit_giant2"):
+            with self.subTest(arch=arch), self.assertRaisesRegex(ValueError, "not available"):
+                _get_weight_spec(arch, Weights.IN21K)
+
+    def test_rasa_layer_count_is_inferred(self):
+        for n_layers in (8, 9):
+            state_dict = {"pos_pred.weight": torch.zeros(2, 16)}
+            state_dict.update({f"pre_pos_layers.{index}.weight": torch.zeros(2, 16) for index in range(n_layers)})
+            with self.subTest(n_layers=n_layers):
+                head = _make_rasa_head(16, state_dict)
+                self.assertEqual(head.n_pos_layers, n_layers)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add explicit 518px Franca and DINOv2 weight variants
- preserve and repair supported legacy checkpoint loading
- infer legacy/current RASA layer counts
- add reproducible checkpoint preparation, verification, and release upload tooling

## Verification
- full forward passes for all six v1.1.0 checkpoint entries
- legacy B/L/G release compatibility checks
- Hub URL routing unit tests
- local and remote SHA-256 asset verification